### PR TITLE
Consolidate adjacent free cells into a larger free cell

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -36,4 +36,37 @@ wasm-opt -Oz \
 
 wc -c ../target/wasm32-unknown-unknown/release/*.gc.opt.wasm
 
+set +x
+
+function dis_does_not_contain {
+    local matches=$(wasm-dis "$1" | grep "$2")
+    if [[ "$matches" != "" ]]; then
+        echo "ERROR! found $2 in $1:"
+        echo
+        echo "$matches"
+        echo
+        echo "wee_alloc should never pull in the panicking infrastructure"
+        exit 1
+    fi
+
+}
+
+function no_panic {
+    dis_does_not_contain $1 "panic"
+}
+
+function no_fmt {
+    dis_does_not_contain $1 "fmt"
+}
+
+function no_write {
+    dis_does_not_contain $1 "Write"
+}
+
+for x in ../target/wasm32-unknown-unknown/release/*.gc.wasm; do
+    no_panic "$x"
+    no_fmt "$x"
+    no_write "$x"
+done
+
 cd -

--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -16,7 +16,8 @@ extern crate wee_alloc;
 static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 
 // Need to provide a tiny `panic_fmt` lang-item implementation for
-// `#![no_std]`. This will just `trap` if we panic in the resulting WebAssembly.
+// `#![no_std]`. This translates into an `unreachable` instruction that will
+// raise a `trap` the WebAssembly execution if we panic at runtime.
 #[lang = "panic_fmt"]
 extern "C" fn panic_fmt(_args: ::core::fmt::Arguments, _file: &'static str, _line: u32) -> ! {
     unsafe {

--- a/test.sh
+++ b/test.sh
@@ -5,8 +5,8 @@ set -eux
 cd $(dirname $0)
 
 cd ./test
-time cargo test --release
-time cargo test --release --features "size_classes"
-time cargo test --release --features "extra_assertions"
 time cargo test --release --features "extra_assertions size_classes"
+time cargo test --release --features "extra_assertions"
+time cargo test --release --features "size_classes"
+time cargo test --release
 cd -

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -10,6 +10,7 @@ quickcheck = "0.6.0"
 [dependencies.wee_alloc]
 path = "../wee_alloc"
 default-features = false
+features = ["use_std_for_test_debugging"]
 
 [features]
 size_classes = ["wee_alloc/size_classes"]

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -307,6 +307,15 @@ fn regression_test_2() {
 }
 
 #[test]
+fn regression_test_3() {
+    Operations::run_single_threaded(Operations(vec![
+        Alloc(13672),
+        Free(0),
+        Alloc(1)
+    ]));
+}
+
+#[test]
 fn allocate_size_zero() {
     use std::iter;
     Operations::run_single_threaded(Operations(

--- a/wee_alloc/Cargo.toml
+++ b/wee_alloc/Cargo.toml
@@ -8,8 +8,15 @@ version = "0.1.0"
 
 [features]
 default = ["size_classes"]
+
+# Enable extra, expensive integrity allocations.
 extra_assertions = []
+
+# Enable size classes for amortized *O(1)* small allocations.
 size_classes = []
+
+# This is for internal use only.
+use_std_for_test_debugging = []
 
 [target.'cfg(all(unix, not(target_arch = "wasm32")))'.dependencies.libc]
 default-features = false

--- a/wee_alloc/src/imp_unix.rs
+++ b/wee_alloc/src/imp_unix.rs
@@ -64,7 +64,7 @@ impl<T> Exclusive<T> {
         let result = f(&mut *self.inner.get());
 
         let code = libc::pthread_mutex_unlock(&mut *self.lock.get());
-        extra_assert_eq!(code, 0, "pthread_mutex_lock should run OK");
+        extra_assert_eq!(code, 0, "pthread_mutex_unlock should run OK");
 
         result
     }

--- a/wee_alloc/src/size_classes.rs
+++ b/wee_alloc/src/size_classes.rs
@@ -1,12 +1,15 @@
-use super::{alloc_with_refill, AllocPolicy, Cell, LargeAllocPolicy};
+use super::{alloc_with_refill, AllocPolicy, CellHeader, FreeCell, LargeAllocPolicy};
 use const_init::ConstInit;
 use core::cmp;
+use core::ptr;
 use imp;
-use units::{Bytes, size_of, RoundUpTo, Words};
+use units::{Bytes, RoundUpTo, Words};
 
 /// An array of free lists specialized for allocations of sizes
 /// `1..Self::NUM_SIZE_CLASSES + 1` words.
-pub(crate) struct SizeClasses(pub(crate) [imp::Exclusive<*mut Cell>; SizeClasses::NUM_SIZE_CLASSES]);
+pub(crate) struct SizeClasses(
+    pub(crate) [imp::Exclusive<*mut FreeCell>; SizeClasses::NUM_SIZE_CLASSES]
+);
 
 impl ConstInit for SizeClasses {
     const INIT: SizeClasses = SizeClasses(include!("size_classes_init.rs"));
@@ -15,7 +18,7 @@ impl ConstInit for SizeClasses {
 impl SizeClasses {
     pub(crate) const NUM_SIZE_CLASSES: usize = 256;
 
-    pub(crate) fn get(&self, size: Words) -> Option<&imp::Exclusive<*mut Cell>> {
+    pub(crate) fn get(&self, size: Words) -> Option<&imp::Exclusive<*mut FreeCell>> {
         extra_assert!(size.0 > 0);
         self.0.get(size.0 - 1)
     }
@@ -25,34 +28,39 @@ impl SizeClasses {
 // `LargeAllocPolicy`.
 const MIN_NEW_CELL_SIZE: Bytes = Bytes(8192);
 
-pub(crate) struct SizeClassAllocPolicy<'a>(pub(crate) &'a imp::Exclusive<*mut Cell>);
+pub(crate) struct SizeClassAllocPolicy<'a>(pub(crate) &'a imp::Exclusive<*mut FreeCell>);
 
 impl<'a> AllocPolicy for SizeClassAllocPolicy<'a> {
-    unsafe fn new_cell_for_free_list(&self, size: Words) -> Result<*mut Cell, ()> {
+    unsafe fn new_cell_for_free_list(&self, size: Words) -> Result<*mut FreeCell, ()> {
         let new_cell_size = cmp::max(size * size, MIN_NEW_CELL_SIZE.round_up_to());
 
         let new_cell = self.0.with_exclusive_access(|head| {
             alloc_with_refill(new_cell_size, head, &LargeAllocPolicy)
         })?;
-        let new_cell = new_cell as *mut Cell;
 
         let new_cell_size: Bytes = new_cell_size.into();
-        Cell::write_initial(new_cell_size - size_of::<Cell>(), new_cell);
+        let next_cell = new_cell.offset(new_cell_size.0 as isize);
+        let next_cell = next_cell as usize | CellHeader::NEXT_CELL_IS_INVALID;
+        extra_assert!(next_cell != 0);
+        let next_cell = ptr::NonNull::new_unchecked(next_cell as *mut CellHeader);
 
-        Ok(new_cell)
+        Ok(FreeCell::from_uninitialized(new_cell, next_cell, None, None, self as &AllocPolicy))
     }
 
     fn min_cell_size(&self, alloc_size: Words) -> Words {
         alloc_size
     }
 
-    #[cfg(feature = "extra_assertions")]
-    fn allocated_sentinel(&self) -> *mut Cell {
-        Cell::SIZE_CLASS_ALLOCATED_NEXT
+    fn should_merge_adjacent_free_cells(&self) -> bool {
+        // It doesn't make sense to merge cells back together when we know it
+        // won't enable satisfying larger requests. There won't be any larger
+        // requests, because we only allocate for a single size. If we merged
+        // cells, they would just split again on the next allocation.
+        false
     }
 
     #[cfg(feature = "extra_assertions")]
     fn free_pattern(&self) -> u8 {
-        Cell::SIZE_CLASS_FREE_PATTERN
+        CellHeader::SIZE_CLASS_FREE_PATTERN
     }
 }


### PR DESCRIPTION
This changes the layout of the cell header, and adds two different overlays for allocated and freed cells. We now have two lists instead of one:

1. a doubly-linked list of all adjacent cells, and
2. a singly-linked list of all free cells.

The second list steals a word from the cell's data payload, which it can safely take because it only deals with unallocated, free cells.

Fixes #1

Fixes #2