### PR TITLE
Use mmap-alloc crate for mmap and Windows VirtualAlloc allocations

### DIFF
--- a/wee_alloc/Cargo.toml
+++ b/wee_alloc/Cargo.toml
@@ -26,3 +26,6 @@ use_std_for_test_debugging = []
 [target.'cfg(all(unix, not(target_arch = "wasm32")))'.dependencies.libc]
 default-features = false
 version = "0.2"
+
+[target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies.mmap-alloc]
+version = "0.2"

--- a/wee_alloc/src/lib.rs
+++ b/wee_alloc/src/lib.rs
@@ -229,6 +229,8 @@ extern crate core;
 
 #[cfg(all(unix, not(target_arch = "wasm32")))]
 extern crate libc;
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+extern crate mmap_alloc;
 
 #[macro_use]
 mod extra_assert;


### PR DESCRIPTION
Per the discussion [here](https://www.reddit.com/r/rust/comments/7we88g/a_wee_allocator_for_webassembly/dtzqjd4/).