### PR TITLE
Fix WASM for LLVM6

### DIFF
--- a/wee_alloc/src/imp_wasm32.rs
+++ b/wee_alloc/src/imp_wasm32.rs
@@ -4,25 +4,15 @@ use core::cell::UnsafeCell;
 use units::Pages;
 
 extern "C" {
-    #[link_name = "llvm.wasm.current.memory.i32"]
-    fn current_memory() -> usize;
-
-    // TODO: this intrinsic actually returns the previous limit, but LLVM
-    // doesn't expose that right now. When we upgrade LLVM stop using
-    // `current_memory` above. Also handle `-1` as an allocation failure.
     #[link_name = "llvm.wasm.grow.memory.i32"]
-    fn grow_memory(pages: usize);
-}
-
-unsafe fn get_base_pointer() -> *mut u8 {
-    (current_memory() * PAGE_SIZE.0) as _
+    fn grow_memory(pages: usize) -> i32;
 }
 
 pub(crate) unsafe fn alloc_pages(n: Pages) -> *mut u8 {
-    let ptr = get_base_pointer();
+    let ptr = grow_memory(n.0);
+    extra_assert!(ptr != -1);
+    let ptr = (ptr as usize * PAGE_SIZE.0) as _;
     assert_is_word_aligned(ptr);
-    extra_assert!(!ptr.is_null());
-    grow_memory(n.0);
     ptr
 }
 


### PR DESCRIPTION
Based on the implementation in [dlmalloc-rs](https://github.com/alexcrichton/dlmalloc-rs/blob/9b2dcac06c3e23235f8997b3c5f2325a6d3382df/src/wasm.rs#L8).

I'm not sure how to handle the error case. Panic? I didn't change the behavior for now.

Also, if I understand the Intrinsic correctly, both input parameter and return value should have the same type. Dlmalloc doesn't follow this either, but it uses a fixed size for the argument. I'm not really sure if this is something that should get changed.

Should fix https://github.com/fitzgen/wee_alloc/issues/16.

