### PR TITLE
Return result from alloc_pages

### DIFF
--- a/wee_alloc/src/imp_unix.rs
+++ b/wee_alloc/src/imp_unix.rs
@@ -5,17 +5,15 @@ use libc;
 use mmap_alloc::MapAllocBuilder;
 use memory_units::{Bytes, Pages};
 
-pub(crate) fn alloc_pages(pages: Pages) -> *mut u8 {
+pub(crate) fn alloc_pages(pages: Pages) -> Result<*mut u8, ()> {
     unsafe {
         let bytes: Bytes = pages.into();
         let layout = Layout::from_size_align_unchecked(bytes.0, 1);
-        // TODO: when we can detect failure of wasm intrinsics, then both
-        // `alloc_pages` implementations should return results, rather than
-        // panicking on failure.
+
         MapAllocBuilder::default()
             .build()
             .alloc(layout)
-            .expect("failed to allocate page")
+            .map_err(|_| ())
     }
 }
 

--- a/wee_alloc/src/imp_wasm32.rs
+++ b/wee_alloc/src/imp_wasm32.rs
@@ -8,12 +8,15 @@ extern "C" {
     fn grow_memory(pages: usize) -> i32;
 }
 
-pub(crate) unsafe fn alloc_pages(n: Pages) -> *mut u8 {
+pub(crate) unsafe fn alloc_pages(n: Pages) -> Result<*mut u8, ()> {
     let ptr = grow_memory(n.0);
-    extra_assert!(ptr != -1);
-    let ptr = (ptr as usize * PAGE_SIZE.0) as _;
-    assert_is_word_aligned(ptr);
-    ptr
+    if -1 != ptr {
+        let ptr = (ptr as usize * PAGE_SIZE.0) as _;
+        assert_is_word_aligned(ptr);
+        Ok(ptr)
+    } else {
+        Err(())
+    }
 }
 
 pub(crate) struct Exclusive<T> {

--- a/wee_alloc/src/imp_windows.rs
+++ b/wee_alloc/src/imp_windows.rs
@@ -10,9 +10,15 @@ use winapi::um::synchapi::{CreateMutexW, ReleaseMutex, WaitForSingleObject};
 use winapi::um::winbase::{WAIT_OBJECT_0, INFINITE};
 use winapi::um::winnt::{HANDLE, MEM_COMMIT, PAGE_READWRITE};
 
-pub(crate) fn alloc_pages(pages: Pages) -> *mut u8 {
+pub(crate) fn alloc_pages(pages: Pages) -> Result<*mut u8, ()> {
     let bytes: Bytes = pages.into();
-    unsafe { VirtualAlloc(NULL, bytes.0, MEM_COMMIT, PAGE_READWRITE) as *mut u8 }
+    let ptr = unsafe { VirtualAlloc(NULL, bytes.0, MEM_COMMIT, PAGE_READWRITE) as *mut u8 };
+
+    if !ptr.is_null() {
+        Ok(ptr)
+    } else {
+        Err(())
+    }
 }
 
 // Cache line size on an i7. Good enough.

--- a/wee_alloc/src/lib.rs
+++ b/wee_alloc/src/lib.rs
@@ -800,7 +800,7 @@ impl AllocPolicy for LargeAllocPolicy {
     unsafe fn new_cell_for_free_list(&self, size: Words) -> Result<*mut FreeCell, ()> {
         let size: Bytes = size.into();
         let pages: Pages = (size + size_of::<CellHeader>()).round_up_to();
-        let new_pages = imp::alloc_pages(pages);
+        let new_pages = imp::alloc_pages(pages)?;
         let allocated_size: Bytes = pages.into();
         let next_cell = new_pages.offset(allocated_size.0 as isize);
         let next_cell = next_cell as usize | CellHeader::NEXT_CELL_IS_INVALID;


### PR DESCRIPTION
As WASM now supports feedback for allocations, it is now possible to
return a result for allocation indicating success and failure.

Following the [documentation for VirtualAlloc](https://msdn.microsoft.com/en-us/library/windows/desktop/aa366887(v=vs.85).aspx), it returns a nullpointer in case of an error. Unfortunately I currently cannot test the windows part myself.