### PR TITLE
Fail if cargo readme output and README.md differs

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -4,11 +4,7 @@ set -eux
 
 cd $(dirname $0)
 
-# Generate new README.md and exit if it differs from the current one.
-OLD_README=`mktemp`
-cp README.md $OLD_README
 cargo readme -r wee_alloc -t "$(pwd)/README.tpl" > README.md
-diff $OLD_README README.md
 
 cd ./wee_alloc
 cargo build

--- a/build.sh
+++ b/build.sh
@@ -4,7 +4,11 @@ set -eux
 
 cd $(dirname $0)
 
+# Generate new README.md and exit if it differs from the current one.
+OLD_README=`mktemp`
+cp README.md $OLD_README
 cargo readme -r wee_alloc -t "$(pwd)/README.tpl" > README.md
+diff $OLD_README README.md
 
 cd ./wee_alloc
 cargo build

--- a/test.sh
+++ b/test.sh
@@ -4,6 +4,12 @@ set -eux
 
 cd $(dirname $0)
 
+# Generate new README.md and exit if it differs from the current one.
+OLD_README=`mktemp`
+cp README.md $OLD_README
+cargo readme -r wee_alloc -t "$(pwd)/README.tpl" > README.md
+diff $OLD_README README.md
+
 cd ./test
 time cargo test --release --features "extra_assertions size_classes"
 time cargo test --release --features "extra_assertions"


### PR DESCRIPTION
https://github.com/fitzgen/wee_alloc/pull/20#issuecomment-365502820

I think, this change will help to catch similar issues earlier.