### PR TITLE
Add an AppVeyor config for Windows CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![](https://img.shields.io/crates/v/wee_alloc.svg)](https://crates.io/crates/wee_alloc)
 [![](https://img.shields.io/crates/d/wee_alloc.svg)](https://crates.io/crates/wee_alloc)
 [![Build Status](https://travis-ci.org/fitzgen/wee_alloc.svg?branch=master)](https://travis-ci.org/fitzgen/wee_alloc)
+[![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/c0mole91so9xaht7?svg=true)](https://ci.appveyor.com/project/DrGoldfire/wee-alloc-7y7e9)
 
 `wee_alloc`: The **W**asm-**E**nabled, **E**lfin Allocator.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,27 @@
+version: "{build}"
+image: Visual Studio 2017
+install:
+- cmd: >-
+    appveyor DownloadFile https://static.rust-lang.org/rustup/dist/i686-pc-windows-gnu/rustup-init.exe
+
+    rustup-init.exe -y --default-toolchain nightly
+
+    set PATH=%PATH%;%USERPROFILE%\.cargo\bin
+build_script:
+- cmd: >-
+    cd %APPVEYOR_BUILD_FOLDER%\wee_alloc
+
+    cargo build
+
+    cargo build --features size_classes
+test_script:
+- cmd: >-
+    cd %APPVEYOR_BUILD_FOLDER%\test
+
+    cargo test --release --features "extra_assertions size_classes"
+
+    cargo test --release --features "extra_assertions"
+
+    cargo test --release --features "size_classes"
+
+    cargo test --release

--- a/wee_alloc/src/lib.rs
+++ b/wee_alloc/src/lib.rs
@@ -4,6 +4,7 @@
 [![](https://img.shields.io/crates/v/wee_alloc.svg)](https://crates.io/crates/wee_alloc)
 [![](https://img.shields.io/crates/d/wee_alloc.svg)](https://crates.io/crates/wee_alloc)
 [![Build Status](https://travis-ci.org/fitzgen/wee_alloc.svg?branch=master)](https://travis-ci.org/fitzgen/wee_alloc)
+[![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/c0mole91so9xaht7?svg=true)](https://ci.appveyor.com/project/DrGoldfire/wee-alloc-7y7e9)
 
 `wee_alloc`: The **W**asm-**E**nabled, **E**lfin Allocator.
 


### PR DESCRIPTION
Think I actually got this working right; it runs fine against my fork, anyway.

The badge links are pointing to my AppVeyor account's config that I just made for this repo, so they'll be a bit confused until this is actually merged, and then it should all spring into action. You'll probably want to make your own AppVeyor login and switch them over to that; you shouldn't have to configure anything, the appveyor.yml here should take care of everything.